### PR TITLE
Fix alt text typo in generator template

### DIFF
--- a/templates/generator.html
+++ b/templates/generator.html
@@ -24,7 +24,7 @@
     <section class="header">
         <div class="header-main">
             <div class="header-main--logo">
-                <img src="/static/images/logo-idear.png" alt="log idear" width="80" />
+                <img src="/static/images/logo-idear.png" alt="logo idear" width="80" />
             </div>
             <div class="header-main--menu">
                 Servicios Tecnológicos Idear


### PR DESCRIPTION
## Summary
- fix a typo in the generator HTML template

## Testing
- `grep -n logo idear templates/generator.html`

------
https://chatgpt.com/codex/tasks/task_e_6846468777a483309da53dff732c66de