### PR TITLE
Fix typo in comment

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ type Page struct {
 
 func main() {
 
-	// multiplexor
+	// multiplexer
 	mux := http.NewServeMux()
 
 	// entry point


### PR DESCRIPTION
## Summary
- fix a typo in `main.go` by renaming `multiplexor` comment to `multiplexer`

## Testing
- `go vet ./...` *(fails: 403 Forbidden on module download)*
- `go build ./...` *(fails: 403 Forbidden on module download)*

------
https://chatgpt.com/codex/tasks/task_e_684646a2ae788330b25b778d49d445bb